### PR TITLE
IPv6 support.

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-pproxy/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-pproxy/run
@@ -7,7 +7,7 @@ fi
 
 s6-svwait -u /run/service/svc-wireproxy && sleep 1s
 
-command="pproxy -l socks5+http://0.0.0.0:${PROXY_PORT}"
+command="pproxy -l socks5+http://:${PROXY_PORT}"
 if [[ -n ${PROXY_USER:-} ]] && [[ -n ${PROXY_PASS:-} ]]; then
     command="$command#${PROXY_USER}:${PROXY_PASS}"
 fi


### PR DESCRIPTION
I'm hosting my app on railway, which supports [private networking only on IPv6](https://docs.railway.com/guides/private-networking).

The proxy was listening exclusively on IPv4 though, so I had to remove the hostname from the pproxy command, "0.0.0.0".

This makes it listen on all interfaces (both IPv4 and IPv6) instead of just IPv4.

Will not break anything AFAIK.

Startup logs before:
<img width="736" alt="Screenshot 2025-06-19 at 5 26 59 PM" src="https://github.com/user-attachments/assets/953a7363-23cb-485f-bdaa-772673ce3c9d" />

Startup logs after:
<img width="700" alt="Screenshot 2025-06-19 at 5 26 15 PM" src="https://github.com/user-attachments/assets/6c001512-0aa4-4bd8-b7ca-741d8e8dcc31" />